### PR TITLE
Add demo dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Install Bazel, https://bazel.build/versions/master/docs/install.html#ubuntu
+FROM openjdk:8
+
+RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list \
+  && curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
+
+RUN apt-get update \
+  && apt-get install -y bazel \
+  && rm -rf /var/lib/apt/lists/*
+
+# Set up workspace
+RUN mkdir -p /usr/src/app
+ENV WORKSPACE /usr/src/app
+WORKDIR /usr/src/app
+
+RUN useradd --uid 1000 --create-home alex


### PR DESCRIPTION
Not merging this, but opened for documentation purposes in case you want to run the app in docker as well. (Quick and dirty it assumes your uid is 1000).

Build with
```
docker build -t bazel-demo .
```

And then run with [my contain script](https://git.sr.ht/~alexdavid/dotfiles/tree/master/bin/contain)
```
contain bazel-demo 8080
```
This will mount your current working directory into docker, set your current user to the same uid and forwards port 8080 to the host. This will allow development without requiring java or bazel to be installed.